### PR TITLE
Basic hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, only feed-forward type models are supported.
 
 At its heart, Zennit registers hooks at PyTorch's Module level, to modify the backward pass to produce LRP
 attributions (instead of the usual gradient).
-All rules are implemented as hooks (`zennit/rules.py`) and most use the basic `LinearHook` (`zennit/core.py`).
+All rules are implemented as hooks (`zennit/rules.py`) and most use the LRP-specific `BasicHook` (`zennit/core.py`).
 **Composites** are a way of choosing the right hook for the right layer.
 In addition to the abstract **NameMapComposite**, which assigns hooks to layers by name, and **LayerMapComposite**,
 which assigns hooks to layers based on their Type, there exist explicit Composites, which currently are

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="zennit",
     use_scm_version=True,
-    packages=['zennit'],
+    packages=find_packages(include=['zennit*']),
     install_requires=[
         'numpy',
         'Pillow',
-        'torch==1.7.0',
+        'torch>=1.7.0',
     ],
     setup_requires=[
         'setuptools_scm',

--- a/zennit/rules.py
+++ b/zennit/rules.py
@@ -1,10 +1,10 @@
 '''Rules based on Hooks'''
 import torch
 
-from .core import Hook, LinearHook, stabilize
+from .core import Hook, BasicHook, stabilize
 
 
-class Epsilon(LinearHook):
+class Epsilon(BasicHook):
     '''Epsilon LRP rule.
 
     Parameters
@@ -22,7 +22,7 @@ class Epsilon(LinearHook):
         )
 
 
-class Gamma(LinearHook):
+class Gamma(BasicHook):
     '''Gamma LRP rule.
 
     Parameters
@@ -40,7 +40,7 @@ class Gamma(LinearHook):
         )
 
 
-class ZPlus(LinearHook):
+class ZPlus(BasicHook):
     '''ZPlus (or alpha=1, beta=0) LRP rule.
 
     Notes
@@ -66,7 +66,7 @@ class ZPlus(LinearHook):
         )
 
 
-class AlphaBeta(LinearHook):
+class AlphaBeta(BasicHook):
     '''AlphaBeta LRP rule.
 
     Parameters
@@ -106,7 +106,7 @@ class AlphaBeta(LinearHook):
         )
 
 
-class ZBox(LinearHook):
+class ZBox(BasicHook):
     '''ZBox LRP rule for input pixel space.
 
     Parameters
@@ -146,7 +146,7 @@ class Pass(Hook):
         return grad_output
 
 
-class Norm(LinearHook):
+class Norm(BasicHook):
     '''Normalize and weigh relevance by input contribution.
     This is essentially the same as the LRP Epsilon Rule with a fixed epsilon only used as a stabilizer, and without
     the need of the attached layer to have parameters `weight` and `bias`.
@@ -162,7 +162,7 @@ class Norm(LinearHook):
         )
 
 
-class WSquare(LinearHook):
+class WSquare(BasicHook):
     '''This is the WSquare LRP rule.'''
     def __init__(self):
         super().__init__(
@@ -174,7 +174,7 @@ class WSquare(LinearHook):
         )
 
 
-class Flat(LinearHook):
+class Flat(BasicHook):
     '''This is the Flat LRP rule. It is essentially the same as the WSquare Rule, but with all parameters set to ones.
     '''
     def __init__(self):


### PR DESCRIPTION
LinearHooks are now BasicHooks and have been renamed in all locations. The docstring for BasicHooks was updated. A bug through which the number of supplied parameters was calculated wrongly was fixed.

find_packages is now used in setup.py to consider possible submodules in future.

Higher versions of PyTorch are now allowed.