### PR TITLE
Style fixes: unused import and binary op linebreak

### DIFF
--- a/share/example/feed_forward.py
+++ b/share/example/feed_forward.py
@@ -1,6 +1,4 @@
 '''A quick example to generate heatmaps for vgg16.'''
-import json
-
 import click
 import torch
 import numpy as np

--- a/zennit/rules.py
+++ b/zennit/rules.py
@@ -99,8 +99,8 @@ class AlphaBeta(BasicHook):
             gradient_mapper=(lambda out_grad, outputs: [out_grad / stabilize(output) for output in outputs]),
             reducer=(
                 lambda inputs, gradients: (
-                    alpha * (inputs[0] * gradients[0] + inputs[1] * gradients[1]) -
-                    beta * (inputs[2] * gradients[2] + inputs[3] * gradients[3])
+                    alpha * (inputs[0] * gradients[0] + inputs[1] * gradients[1])
+                    - beta * (inputs[2] * gradients[2] + inputs[3] * gradients[3])
                 )
             )
         )


### PR DESCRIPTION
- removed the unused json import from the feed forward example
- moved a binary operator from the end of line to the beginning of the next
line in rules.py