### PR TITLE
Pass parameter names to param_mod to fix ZPlus and AlphaBeta negative params

### DIFF
--- a/zennit/core.py
+++ b/zennit/core.py
@@ -83,7 +83,7 @@ def mod_params(module, modifier, param_keys=None, require_params=True):
                 param = getattr(module, key)
                 if param is not None:
                     stored_tensors[key] = param.data
-                    param.data = modifier(param.data)
+                    param.data = modifier(param.data, key)
         yield module
     finally:
         for key, value in stored_tensors.items():
@@ -302,7 +302,7 @@ class BasicHook(Hook):
         )
 
     @staticmethod
-    def _default_modifier(obj):
+    def _default_modifier(obj, _):
         return obj
 
     @staticmethod


### PR DESCRIPTION
- `mod_params` will now pass the parameter name as the second positional
  argument to `param_mod`
- this makes parameters distinguishable, such that they can be modified
  differently
- rules implemented using BasicHook were adapted: the param_mod
  functions now need a second positional argument
- custom rules must be updated in the same way

- this update fixes in the rules ZPlus and AlphaBeta, which were incorrect
  when there were negative biases, as having negative biases can in any
  case cause negative outputs
- the rules' param_mod functions specifically handle parameters named
  'bias' differently