### PR TITLE
Fixed default_modifier

### DIFF
--- a/zennit/core.py
+++ b/zennit/core.py
@@ -302,7 +302,7 @@ class BasicHook(Hook):
         )
 
     @staticmethod
-    def _default_modifier(obj, _):
+    def _default_modifier(obj, name=None):
         return obj
 
     @staticmethod


### PR DESCRIPTION
- default modifier worked only with two arguments, but since it was used
  both for input and param mods, using the default params for BasicHook
  caused a crash