### PR TITLE
 Docs: Clarification about requirements Modules/ Canonizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Zennit (**Z**ennit **e**xplains **n**eural **n**etworks **i**n **t**orch)
 is a high-level framework in Python using PyTorch for explaining/exploring neural networks.
 Its design philosophy is intended to provide high customizability and integration as a standardized solution
 for applying LRP-based attribution methods in research.
+Zennit strictly requires models to use PyTorch's `torch.nn.Module` structure
+(including activation functions).
 
 Zennit is currently under development and has not yet reached a stable state.
 Interfaces may change suddenly and without warning, so please be careful when attempting to use Zennit in its current

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -24,9 +24,11 @@ Basic Usage
 -----------
 
 Zennit implements propagation-based attribution methods by overwriting the
-gradient of PyTorch modules in PyTorch's auto-differentiation engine. The
-following demonstrates a setup to compute Layerwise Relevance Propagation (LRP)
-relevance for a simple model and random data.
+gradient of PyTorch modules in PyTorch's auto-differentiation engine. This means
+that Zennit will only work on models which are strictly implemented using
+PyTorch modules, including activation functions. The following demonstrates a
+setup to compute Layerwise Relevance Propagation (LRP) relevance for a simple
+model and random data.
 
 .. code-block:: python
 
@@ -43,7 +45,8 @@ relevance for a simple model and random data.
     )
     input = torch.randn(1, 3, 32, 32)
 
-The most important high-level structures in Zennit are ``Composites``, ``Attributors`` and ``Canonizers``.
+The most important high-level structures in Zennit are ``Composites``,
+``Attributors`` and ``Canonizers``.
 
 
 Composites
@@ -121,7 +124,8 @@ may be combined with propagation-based (composite) approaches.
 
     print('SmoothGrad:', relevance)
 
-More information on attributors can be found in :doc:`/how-to/use-attributors` and :doc:`/how-to/write-custom-attributors`.
+More information on attributors can be found in :doc:`/how-to/use-attributors`
+and :doc:`/how-to/write-custom-attributors`.
 
 Canonizers
 ^^^^^^^^^^
@@ -157,7 +161,10 @@ be simply supplied when instantiating a composite:
 Some pre-defined canonizers for models from ``torchvision`` can be found in
 :py:mod:`zennit.torchvision`. The :py:class:`zennit.torchvision.VGGCanonizer`
 specifically is simply :py:class:`zennit.canonizers.SequentialMergeBatchNorm`,
-which may be used when ``BatchNorm`` is used in sequential models. For more
+which may be used when ``BatchNorm`` is used in sequential models. Note that for
+``SequentialMergeBatchNorm`` to work, all functions (linear layers, activations,
+...) must be modules and assigned to their parent module in the order they are
+visited (see :py:class:`zennit.canonizers.SequentialMergeBatchNorm`). For more
 information on canonizers see :doc:`/how-to/use-composites-and-canonizers` and
 :doc:`/how-to/write-custom-canonizers`.
 

--- a/zennit/canonizers.py
+++ b/zennit/canonizers.py
@@ -151,7 +151,17 @@ class MergeBatchNorm(Canonizer):
 
 
 class SequentialMergeBatchNorm(MergeBatchNorm):
-    '''Canonizer to merge the parameters of all batch norms that appear sequentially right after a linear module.'''
+    '''Canonizer to merge the parameters of all batch norms that appear sequentially right after a linear module.
+
+    Note
+    ----
+    SequentialMergeBatchNorm traverses the tree of children of the provided module depth-first and in-order.
+    This means that child-modules must be assigned to their parent module in the order they are visited in the forward
+    pass to correctly identify adjacent modules.
+    This also means that activation functions must be assigned in their module-form as a child to their parent-module
+    to properly detect when there is an activation function between linear and batch-norm modules.
+
+    '''
     def apply(self, root_module):
         '''Finds a batch norm following right after a linear layer, and creates a copy of this instance to merge
         them by fusing the batch norm parameters into the linear layer and reducing the batch norm to the identity.


### PR DESCRIPTION
 - added Note to `SequentialBatchNorm` to clarify the assumptions made to detect adjacent modules
- clarify the requirement of models to be implemented using pytorch
  modules in `getting-started.rst` and `README.md`
- clarify the requirement of ordered children in sequential models for
  `SequentialMergeBatchNorm` in `getting-started.rst`

Closes #63 