### PR TITLE
Fix: Occlusion stride resolve

### DIFF
--- a/zennit/attribution.py
+++ b/zennit/attribution.py
@@ -380,7 +380,7 @@ class Occlusion(Attributor):
         if isinstance(window, int):
             window = tuple(min(window, size) for size in input.shape)
         if isinstance(stride, int):
-            window = tuple(min(stride, size) for size in input.shape)
+            stride = tuple(min(stride, size) for size in input.shape)
 
         if len(window) < input.ndim:
             window = tuple(input.shape)[:input.ndim - len(window)] + window


### PR DESCRIPTION
- the resolved size for the Occlusion's sliding window's stride was
  wrongly assigned as the window size when supplying the stride size as
  an integer