### PR TITLE
Updated test environment with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,60 @@
 [tox]
-skip_missing_interpreters = True
-envlist = py38,pylint,flake8
+skip_missing_interpreters = true
+envlist = py37,py38,py39,pylint,flake8,docs
+
+[testenv]
+deps =
+   pytest
+   pytest-cov
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
+commands =
+    pytest \
+        --cov "{envsitepackagesdir}/zennit" \
+        --cov-config "{toxinidir}/tox.ini" \
+        {posargs:.}
+
+[testenv:coverage]
+deps =
+   coverage
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report -m
+depends = py37,py38,py39
+
+[testenv:docs]
+basepython = python3.9
+deps =
+    -r {toxinidir}/docs/requirements.txt
+commands =
+    sphinx-build \
+        --color \
+        -W \
+        --keep-going \
+        -d "{toxinidir}/docs/doctree" \
+        -b html \
+        {toxinidir}/docs/source \
+        {toxinidir}/build
+
+[testenv:flake8]
+basepython = python3.9
+changedir = {toxinidir}
+deps =
+    flake8
+commands =
+    flake8 "{toxinidir}/zennit" "{toxinidir}/tests"
+
+[testenv:pylint]
+basepython = python3.9
+deps =
+    pylint
+    pytest
+changedir = {toxinidir}
+commands =
+    pylint --rcfile=pylintrc --output-format=parseable {toxinidir}/zennit {toxinidir}/tests
 
 [flake8]
 # R0902 Too many instance attributes
@@ -13,27 +67,19 @@ exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
 
 max-line-length = 120
 
-[testenv]
-deps =
-   pytest
-   pytest-cov
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage.{envname}
-commands =
-    python -m pytest --cov=zennit {toxinidir}/tests/ {posargs:}
-changedir = {toxworkdir}
+[pytest]
+testpaths = tests
+addopts = -ra -l
 
-[testenv:flake8]
-changedir = {toxinidir}
-deps =
-    flake8
-commands =
-    flake8 {toxworkdir} {posargs}
+[coverage:run]
+parallel = true
+branch = true
 
-[testenv:pylint]
-deps =
-    pylint
-    pytest
-changedir = {toxinidir}
-commands =
-    python -m pylint --rcfile=pylintrc --output-format=parseable zennit tests
+[coverage:report]
+skip_covered = true
+show_missing = true
+
+[coverage:paths]
+source = zennit
+    */.tox/*/lib/python*/site-packages/zennit
+    */zennit


### PR DESCRIPTION
- added py39 environment
- added coverage config
- added coverage environment
- added pytest config
- added docs environment to build documentation
- added basepython for flake8 and pylint
- removed `tests/__init__.py`, which interfered with pytest/coverage