### PR TITLE
Update pylintrc and introduce style fixes

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -149,6 +149,10 @@ disable=print-statement,
         abstract-method,
         too-many-public-methods,
         redefined-builtin,
+        arguments-differ,
+        no-value-for-parameter,
+        unused-argument,
+        bad-staticmethod-argument,
 
 
 
@@ -536,7 +540,7 @@ max-attributes=7
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=25
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from torch.nn import BatchNorm1d, BatchNorm2d, BatchNorm3d
 
 
 def prodict(**kwargs):
+    '''Create a dictionary with values which are the cartesian product of the input keyword arguments.'''
     return [dict(zip(kwargs, val)) for val in product(*kwargs.values())]
 
 
@@ -21,6 +22,7 @@ def prodict(**kwargs):
     ]]
 ])
 def rng(request):
+    '''Random number generator fixture.'''
     return torch.manual_seed(request.param)
 
 
@@ -35,12 +37,14 @@ def rng(request):
     ),
 ])
 def module_linear(rng, request):
+    '''Fixture for linear modules.'''
     module_type, kwargs = request.param
     return module_type(**kwargs).to(torch.float64).eval()
 
 
 @pytest.fixture(scope='session')
 def module_batchnorm(module_linear):
+    '''Fixture for BatchNorm-type modules, based on adjacent linear module.'''
     module_map = [
         ((Linear, Conv1d, ConvTranspose1d), BatchNorm1d),
         ((Conv2d, ConvTranspose2d), BatchNorm2d),
@@ -72,6 +76,7 @@ def module_batchnorm(module_linear):
 
 @pytest.fixture(scope='session')
 def data_input(rng, module_linear):
+    '''Fixture to create data for a linear module, given an RNG.'''
     shape = (4,)
     setups = [
         (Conv1d, 1, 1),

--- a/tests/test_canonizers.py
+++ b/tests/test_canonizers.py
@@ -5,6 +5,7 @@ from zennit.canonizers import SequentialMergeBatchNorm
 
 
 def test_merge_batchnorm_consistency(module_linear, module_batchnorm, data_input):
+    '''Test whether the output of the merged batchnorm is consistent with its original output.'''
     output_linear_before = module_linear(data_input)
     output_batchnorm_before = module_batchnorm(output_linear_before)
     canonizer = SequentialMergeBatchNorm()
@@ -19,9 +20,9 @@ def test_merge_batchnorm_consistency(module_linear, module_batchnorm, data_input
     output_linear_after = module_linear(data_input)
     output_batchnorm_after = module_batchnorm(output_linear_after)
 
-    assert all([torch.allclose(left, right, atol=1e-5) for left, right in [
+    assert all(torch.allclose(left, right, atol=1e-5) for left, right in [
         (output_linear_before, output_linear_after),
         (output_batchnorm_before, output_batchnorm_after),
         (output_batchnorm_before, output_linear_canonizer),
         (output_linear_canonizer, output_batchnorm_canonizer),
-    ]])
+    ])

--- a/zennit/attribution.py
+++ b/zennit/attribution.py
@@ -24,16 +24,64 @@ import torch
 
 
 def constant(obj):
+    '''Wrapper function to create a function which returns a constant object regardless of arguments.
+
+    Parameters
+    ----------
+    obj : object
+        Constant object which the returned wrapper function will return on call.
+
+    Returns
+    -------
+    wrapped_const : function
+        Function which when called with any arguments will return ``obj``.
+
+    '''
     def wrapped_const(*args, **kwargs):
         return obj
     return wrapped_const
 
 
 def identity(obj):
+    '''Identity function.
+
+    Parameters
+    ----------
+    obj : object
+        Any object which will be returned.
+
+    Result
+    ------
+    obj : object
+        The original input argument ``obj``.
+
+    '''
     return obj
 
 
 def occlude_independent(input, mask, fill_fn=torch.zeros_like, invert=False):
+    '''Given a ``mask``, occlude pixels of ``input`` independently given a function ``fill_fn``.
+
+    Parameters
+    ----------
+    input : :py:obj:`torch.Tensor`
+        The input tensor which will be occluded in the pixels where ``mask`` is non-zero, or, if ``invert`` is
+        ``True``, where ``mask`` is zero, using function ``fill_fn``.
+    mask : :py:obj:`torch.Tensor`
+        Boolean mask, at which non-zero or zero (given ``invert``) elements will be occluded in ``input``.
+    fill_fn : function, optional
+        Function used to occlude pixels with signature ``(input : torch.Tensor) -> torch.Tensor``, where input is the
+        same shape as ``input``, and the output shall leave the shape unchanged. Default is ``torch.zeros_like``, which
+        will replace occluded pixels with zero.
+    invert : bool, optional
+        If ``True``, inverts the supplied mask. Default is ``False``, i.e. not to invert.
+
+    Returns
+    -------
+    :py:obj:`torch.Tensor`
+        The occluded tensor.
+
+    '''
     if invert:
         mask = ~mask
     return input * mask + ~mask * fill_fn(input)
@@ -150,8 +198,9 @@ class Attributor(metaclass=ABCMeta):
 
 
 class Gradient(Attributor):
-    '''The Gradient Attributor. The result is the product of the attribution output and the (possibly modified) jacobian.
-    With a composite, i.e. `EpsilonGammaBox`, this will compute the Layerwise Relevance Propagation attribution values.
+    '''The Gradient Attributor. The result is the product of the attribution output and the (possibly modified)
+    jacobian. With a composite, i.e. `EpsilonGammaBox`, this will compute the Layerwise Relevance Propagation
+    attribution values.
     '''
     def forward(self, input, attr_output_fn):
         '''Compute the gradient of the model wrt. input, by using `attr_output_fn` as the function of the model output
@@ -278,8 +327,8 @@ class IntegratedGradients(Attributor):
     References
     ----------
     .. [2] M. Sundararajan, A. Taly, and Q. Yan, “Axiomatic attribution for deep networks,” in Proceedings of the 34th
-       International Conference on Machine Learning, ICML 2017, Sydney, NSW, Australia, 6-11 August 2017, ser. Proceedings
-       of Machine Learning Research, D. Precup and Y. W. Teh, Eds., vol. 70. PMLR, 2017, pp. 3319–3328.
+       International Conference on Machine Learning, ICML 2017, Sydney, NSW, Australia, 6-11 August 2017, ser.
+       Proceedings of Machine Learning Research, D. Precup and Y. W. Teh, Eds., vol. 70. PMLR, 2017, pp. 3319–3328.
 
     '''
     def __init__(self, model, composite=None, attr_output=None, baseline_fn=None, n_iter=20):

--- a/zennit/cmap.py
+++ b/zennit/cmap.py
@@ -71,10 +71,11 @@ class ColorMap:
     )
 
     def __init__(self, source):
-        self.source = source
+        self._source = source
 
     @property
     def source(self):
+        '''Source code property. Assignment causes re-compilation.'''
         return self._source
 
     @source.setter
@@ -125,7 +126,7 @@ class ColorMap:
                 raise RuntimeError(f'Unexpected {token}')
 
         if log and log[-1].type not in ('shortcolor', 'longcolor'):
-            raise RuntimeError(f'Unexpected {token}')
+            raise RuntimeError(f'Unexpected {log[-1]}')
 
         return nodes
 
@@ -147,8 +148,7 @@ class ColorMap:
                 if n < len(nodes) - 1:
                     log.append(node)
                     continue
-                else:
-                    node = ColorNode(255, node.value)
+                node = ColorNode(255, node.value)
             elif node.index < result[-1].index:
                 raise RuntimeError('ColorMap indices not ordered! Provided indices are required in ascending order.')
             if log:
@@ -235,7 +235,7 @@ class LazyColorMapCache:
         if name in self._compiled:
             self._compiled[name].source = value
 
-    def __delitem__(self, name, value):
+    def __delitem__(self, name):
         del self._sources[name]
         if name in self._compiled:
             del self._compiled[name]

--- a/zennit/core.py
+++ b/zennit/core.py
@@ -77,7 +77,8 @@ def mod_params(module, modifier, param_keys=None, require_params=True):
 
         missing = [key for key in param_keys if not hasattr(module, key)]
         if require_params and missing:
-            raise RuntimeError('Module {} requires missing parameters: \'{}\''.format(module, '\', \''.join(missing)))
+            missing_str = '\', \''.join(missing)
+            raise RuntimeError(f'Module {module} requires missing parameters: \'{missing_str}\'')
 
         for key in param_keys:
             if key not in missing:

--- a/zennit/image.py
+++ b/zennit/image.py
@@ -65,7 +65,7 @@ def get_cmap(cmap):
     '''
     if isinstance(cmap, ColorMap):
         return cmap
-    elif cmap in CMAPS:
+    if cmap in CMAPS:
         return CMAPS[cmap]
     return ColorMap(cmap)
 
@@ -134,7 +134,7 @@ def imgify(obj, vmin=None, vmax=None, cmap='bwr', level=1.0, symmetric=False, gr
     try:
         array = np.array(obj)
     except TypeError as err:
-        raise TypeError('Could not cast instance of \'{}\' to numpy array.'.format(str(type(obj)))) from err
+        raise TypeError(f'Could not cast \'{obj}\' to numpy array.') from err
 
     if grid:
         if isinstance(grid, (list, tuple)) and len(grid) != 2:
@@ -228,7 +228,7 @@ def gridify(obj, shape=None, fill_value=None):
     try:
         array = np.array(obj)
     except TypeError as err:
-        raise TypeError('Could not cast instance of \'{}\' to numpy array.'.format(str(type(obj)))) from err
+        raise TypeError(f'Could not cast \'{obj}\' to numpy array.') from err
     if array.ndim not in (3, 4):
         raise TypeError('For creating an image grid, the array has to have either 3 (greyscale) or 4 (rgb) axes!')
 

--- a/zennit/rules.py
+++ b/zennit/rules.py
@@ -211,12 +211,14 @@ class Flat(BasicHook):
 
 
 class ReLUDeconvNet(Hook):
+    '''Hook to modify ReLU gradient according to DeconvNet.'''
     def backward(self, module, grad_input, grad_output):
         '''Modify ReLU gradient according to DeconvNet.'''
         return (grad_output[0].clamp(min=0),)
 
 
 class ReLUGuidedBackprop(Hook):
+    '''Hook to modify ReLU gradient according to GuidedBackprop.'''
     def backward(self, module, grad_input, grad_output):
         '''Modify ReLU gradient according to GuidedBackprop.'''
         return (grad_input[0] * (grad_output[0] > 0.),)


### PR DESCRIPTION
### Style fixes for tests/test_canonizers.py

- missing docstring for merge_batchnorm_consistency
- assertion list comprehension changed to generator

### Added docstrings to tests/conftest.py fixtures

### Added missing docstrings in rules.py

- for ReLUDeconvNet and ReLUGuidedBackprop

### Style fixes for image.py

- use f-strings in array cast RuntimeErrors
- replace an unnecessary `elif` with an `if`

### Use f-string in core.py RuntimeError

### Style-/bug fixes for cmap.py

- missing docstring
- mistakenly assigned self.source instead of self._source for `ColorMap`
- LazyColorMapCache.__del__ had one argument too many

### Added missing docstring in attribution.py

### Disable undesired pylint errors
