### PR TITLE
Expand low/high in ZBox to improve usability

### DIFF
--- a/zennit/rules.py
+++ b/zennit/rules.py
@@ -18,7 +18,7 @@
 '''Rules based on Hooks'''
 import torch
 
-from .core import Hook, BasicHook, stabilize
+from .core import Hook, BasicHook, stabilize, expand
 
 
 class Epsilon(BasicHook):
@@ -145,8 +145,8 @@ class ZBox(BasicHook):
         super().__init__(
             input_modifiers=[
                 lambda input: input,
-                lambda input: low[:input.shape[0]],
-                lambda input: high[:input.shape[0]],
+                lambda input: expand(low, input.shape, cut_batch_dim=True).to(input),
+                lambda input: expand(high, input.shape, cut_batch_dim=True).to(input),
             ],
             param_modifiers=[
                 lambda param, _: param,


### PR DESCRIPTION
- add zennit.core.expand, which expands tensors to a shape, in a more
  lenient fashion than simply torch.expand:
    - allow scalars (0-dim tensor or float/int)
    - assume trailing dimensions to be singleton if number of dimensions
      is smaller than target number of timensions
    - [backwards-compatibility] cut first (batch) dimension to `shape`
      if the supplied first dimension is larger (only if cut_batch_dim
      flag is set True)
- use expand in zennit.rules.ZBox to expand `low` and `high`