### PR TITLE
Test Simple Module Rules

### DIFF
--- a/tests/test_canonizers.py
+++ b/tests/test_canonizers.py
@@ -4,20 +4,20 @@ import torch
 from zennit.canonizers import SequentialMergeBatchNorm
 
 
-def test_merge_batchnorm_consistency(module_linear, module_batchnorm, data_input):
+def test_merge_batchnorm_consistency(module_linear, module_batchnorm, data_linear):
     '''Test whether the output of the merged batchnorm is consistent with its original output.'''
-    output_linear_before = module_linear(data_input)
+    output_linear_before = module_linear(data_linear)
     output_batchnorm_before = module_batchnorm(output_linear_before)
     canonizer = SequentialMergeBatchNorm()
 
     try:
         canonizer.register((module_linear,), module_batchnorm)
-        output_linear_canonizer = module_linear(data_input)
+        output_linear_canonizer = module_linear(data_linear)
         output_batchnorm_canonizer = module_batchnorm(output_linear_canonizer)
     finally:
         canonizer.remove()
 
-    output_linear_after = module_linear(data_input)
+    output_linear_after = module_linear(data_linear)
     output_batchnorm_after = module_batchnorm(output_linear_after)
 
     assert all(torch.allclose(left, right, atol=1e-5) for left, right in [


### PR DESCRIPTION
- added simple module fixtures, for simple, element-wise, parameter-less
  modules like ReLU
- added simple data fixtures for the simple layers
- made batch-size a pytest CLI option, defaulting to 4
- added tests for rules that only apply to simple layers