### PR TITLE
Tox: add {posargs} to environments docs and flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,8 @@ commands =
         -d "{toxinidir}/docs/doctree" \
         -b html \
         "{toxinidir}/docs/source" \
-        "{toxinidir}/docs/build"
+        "{toxinidir}/docs/build" \
+        {posargs}
 
 [testenv:flake8]
 basepython = python3.9
@@ -45,7 +46,8 @@ changedir = {toxinidir}
 deps =
     flake8
 commands =
-    flake8 "{toxinidir}/zennit" "{toxinidir}/tests"
+    flake8 "{toxinidir}/zennit" "{toxinidir}/tests" {posargs}
+
 
 [testenv:pylint]
 basepython = python3.9


### PR DESCRIPTION
- this is for example useful to do `tox -e docs -- -aE` to rebuild the
  whole documentation including all unchanged files