### PR TITLE
Move RTD-config to .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
-  version: "3.8"
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .


### PR DESCRIPTION
- previously, built options were specified on readthedocs.org's user
  interface
- the specific configuration has now properly been moved into
  the supported .readthedocs.yaml