### PR TITLE
Occlusion: No multiply attr_output_fn with output

### DIFF
--- a/docs/source/how-to/use-attributors.rst
+++ b/docs/source/how-to/use-attributors.rst
@@ -138,9 +138,9 @@ window:
         )
     )
     with attributor:
-        # for occlusion, the tracked score is the vector product of the
-        # provided *grad_output* and the model's output
-        output, relevance = attributor(input, torch.eye(10)[[0]])
+        # for occlusion, the score for each window-pass is the sum of the
+        # provided *grad_output*, which we choose as the model output at index 0
+        output, relevance = attributor(input, lambda out: torch.eye(10)[[0]] * out)
 
 
 Note that while the interface allows to pass a composite for any

--- a/src/zennit/attribution.py
+++ b/src/zennit/attribution.py
@@ -469,7 +469,7 @@ class Occlusion(Attributor):
             occluded_input = self.occlusion_fn(input, mask)
             with torch.no_grad():
                 output = self.model(occluded_input)
-            score = (attr_output_fn(output) * output).sum(tuple(range(1, output.ndim)))
+            score = attr_output_fn(output).sum(tuple(range(1, output.ndim)))
             result += mask * score[(slice(None),) + (None,) * (input.ndim - 1)]
 
         output = self.model(input)


### PR DESCRIPTION
- do not multiply the output of attr_output_fn with the model's output,
  as this is neither intuitive nor flexible
- instead, only sum over the attr_output_fn output to compute the
  batch-wise scores
- in share/example/feed_forward.py: specify an attr_output function instead
  of a one-hot tensor, which uses only the output of the true label
  index, thus retaining the previous behavior and demonstration how to
  use the output function
- in docs/source/how-to/use-attributors.rst: use a lambda expression for
  the occlusion attributor to demonstrate how to use score only for a
  certain index with the *new* interface