### PR TITLE
Occlusion: Type-check both window and stride

### DIFF
--- a/src/zennit/attribution.py
+++ b/src/zennit/attribution.py
@@ -409,7 +409,7 @@ class Occlusion(Attributor):
     '''
     def __init__(self, model, composite=None, attr_output=None, occlusion_fn=None, window=8, stride=8):
         def typecheck(obj):
-            return isinstance(window, int) or isinstance(window, tuple) and all(isinstance(elem, int) for elem in obj)
+            return isinstance(obj, int) or isinstance(obj, tuple) and all(isinstance(elem, int) for elem in obj)
 
         super().__init__(model=model, composite=composite, attr_output=attr_output)
 


### PR DESCRIPTION
- the type-check in Occlusion for window and stride mistakenly only
  checked the type of window twice instead of once for each
- now it checks both as originally intended