### PR TITLE
Cmap: Precise uint8 palettes

### DIFF
--- a/src/zennit/cmap.py
+++ b/src/zennit/cmap.py
@@ -202,10 +202,10 @@ class ColorMap:
         obj:`numpy.ndarray`
             The palette described by an unsigned 8-bit numpy array with 256 entries.
         '''
-        x = np.linspace(-1., 1., 256) * level
+        x = np.linspace(-1., 1., 256, dtype=np.float64) * level
         x = ((x + 1.) / 2.).clip(0., 1.)
         x = self(x)
-        x = (x * 255.).clip(0., 255.).astype(np.uint8)
+        x = (x * 255.).round(12).clip(0., 255.).astype(np.uint8)
         return x
 
 


### PR DESCRIPTION
- due to extremely insignificant rounding errors, palettes generated
  using ColorMap.palette were sometimes rounded down by mistake
- palette now enforces float64, and rounds to the 12th decimal to make
  the color maps more precise