### PR TITLE
Fix escaping issue with older Bash versions

### DIFF
--- a/share/scripts/download-lighthouses.sh
+++ b/share/scripts/download-lighthouses.sh
@@ -174,7 +174,7 @@ parse_params "$@"
 command -v curl >/dev/null || die "curl not available!" 1
 command -v file >/dev/null || die "file not available!" 1
 
-mkdir -p "${wnids[@]/#/"$output/"}"
+mkdir -p "${wnids[@]/#/$output/}"
 
 echo -n "Downloading: "
 n_loaded=0


### PR DESCRIPTION
- downloading lighthouses dataset failed due to escaping issue with
  older Bash versions (tested with 3.2.57)