### PR TITLE
Add GPU support for occlusion attributor.

### DIFF
--- a/src/zennit/attribution.py
+++ b/src/zennit/attribution.py
@@ -460,7 +460,7 @@ class Occlusion(Attributor):
         '''
         window, stride = self._resolve_window_stride(input)
 
-        root_mask = torch.zeros(input.shape, dtype=bool)
+        root_mask = torch.zeros_like(input, dtype=bool)
         root_mask[tuple(slice(0, elem) for elem in window)] = True
 
         result = torch.zeros_like(input)


### PR DESCRIPTION
This changes will pay attention to the device while `root_mask` creation.

---

Fixes `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

![image](https://user-images.githubusercontent.com/5962361/169819226-07b92875-7f22-4c74-abe0-07b6fc0cc143.png)
