### PR TITLE
Docs: Switch to MathJAX

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-      - name: Install texlive and pandoc
-        run: sudo apt-get update -y && sudo apt-get install -y texlive texlive-latex-extra dvipng pandoc
+      - name: Install pandoc
+        run: sudo apt-get update -y && sudo apt-get install -y pandoc
       - name: Install tox
         run: python -m pip install tox
       - name: Setup test environment

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.linkcode',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
     'sphinx.ext.extlinks',
     'sphinx_rtd_theme',
     'sphinx_copybutton',


### PR DESCRIPTION
- switch to mathjax for more beautiful math in the documentation;
  initially I used pngmath to support offline-documentation, however, I
  do not feel this is a common enough case to justify the trade-off paid
  by using images
- update github workflow: we do not need texlive anymore for the docs
  when using mathjax