### PR TITLE
Package: Import all modules in zennit/__init__.py

### DIFF
--- a/src/zennit/__init__.py
+++ b/src/zennit/__init__.py
@@ -1,0 +1,25 @@
+'''Zennit top-level __init__.'''
+from . import attribution
+from . import canonizers
+from . import cmap
+from . import composites
+from . import core
+from . import image
+from . import layer
+from . import rules
+from . import torchvision
+from . import types
+
+
+__all__ = [
+    'attribution',
+    'canonizers',
+    'cmap',
+    'composites',
+    'core',
+    'image',
+    'layer',
+    'rules',
+    'torchvision',
+    'types',
+]


### PR DESCRIPTION
- to enable top-level import of zennit
- I did not initially do this as I did not feel this was necessary; now
  I feel differently