### PR TITLE
README: Remove Example Script, add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing Guide for Zennit
+
+Thank you for your interest in contributing to Zennit!
+
+If you would like to fix a bug or add a feature, please write an issue before submitting a pull request.
+
+
+## Git
+We use a linear git-history, where each commit contains a full feature/bug fix,
+such that each commit represents an executable version.
+The commit message contains a subject followed by an empty line, followed by a detailed description, similar to the following:
+
+```
+Category: Short subject describing changes (50 characters or less)
+
+- detailed description, wrapped at 72 characters
+- bullet points or sentences are okay
+- all changes should be documented and explained
+- valid categories are, for example:
+    - `Docs` for documentation
+    - `Tests` for tests
+    - `Composites` for changes in composites
+    - `Core` for core changes
+    - `Package` for package-related changes, e.g. in setup.py
+```
+
+We recommend to not use `-m` for committing, as this often results in very short commit messages.
+
+## Code Style
+We use [PEP8](https://www.python.org/dev/peps/pep-0008) with a line-width of 120 characters. For
+docstrings we use [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html).
+
+We use [`flake8`](https://pypi.org/project/flake8/) for quick style checks and
+[`pylint`](https://pypi.org/project/pylint/) for thorough style checks.
+
+## Testing
+Tests are written using [Pytest](https://docs.pytest.org) and executed
+in a separate environment using [Tox](https://tox.readthedocs.io/en/latest/).
+
+A full style check and all tests can be run by simply calling `tox` in the repository root.
+
+If you add a new feature, please also include appropriate tests to verify its intended functionality.
+We try to keep the code coverage close to 100%.
+
+## Documentation
+The documentation uses [Sphinx](https://www.sphinx-doc.org). It can be built at
+`docs/build` using the respective Tox environment with `tox -e docs`. To rebuild the full
+documentation, `tox -e docs -- -aE` can be used.
+
+The API-documentation is generated from the numpycodestyle docstring of respective modules/classes/functions.
+
+### Tutorials
+Tutorials are written as Jupyter notebooks in order to execute them using
+[Binder](https://mybinder.org/) or [Google
+Colab](https://colab.research.google.com/).
+They are found at [`docs/source/tutorial`](docs/source/tutorial).
+Their output should be empty when committing, as they will be executed when
+building the documentation.
+To reduce the building time of the documentation, their execution time should
+be kept short, i.e. large files like model parameters should not be downloaded
+automatically.
+To include parameter files for users, include a comment which describes how to
+use the full model/data, and provide the necessary code in a comment or an if-condition
+which always evaluates to `False`.
+
+## Continuous Integration
+Linting, tests and the documentation are all checked using a Github Actions
+workflow which executes the appropriate tox environments.

--- a/README.md
+++ b/README.md
@@ -101,88 +101,18 @@ with Gradient(model=model, composite=composite) as attributor:
     out, relevance = attributor(data, torch.eye(1000)[[0]])
 ```
 
+A similar setup using [the example script](share/example/feed_forward.py)
+produces the following attribution heatmaps:
+![beacon heatmaps](share/img/beacon_vgg16_epsilon_gamma_box.png)
+
 For more details and examples, have a look at our
 [**documentation**](https://zennit.readthedocs.io/en/latest/).
 
-## Example
-This example demonstrates how the script at
-[`share/example/feed_forward.py`](share/example/feed_forward.py) can be used to
-generate attribution heatmaps for VGG16.
-It requires bash, cURL and (magic-)file.
-
-Create a virtual environment, install Zennit and download the example scripts:
-```shell
-$ mkdir zennit-example
-$ cd zennit-example
-$ python -m venv .venv
-$ .venv/bin/pip install zennit
-$ curl -o feed_forward.py \
-    'https://raw.githubusercontent.com/chr5tphr/zennit/master/share/example/feed_forward.py'
-$ curl -o download-lighthouses.sh \
-    'https://raw.githubusercontent.com/chr5tphr/zennit/master/share/scripts/download-lighthouses.sh'
-```
-
-Prepare the data needed for the example :
-```shell
-$ mkdir params data results
-$ bash download-lighthouses.sh --output data/lighthouses
-$ curl -o params/vgg16-397923af.pth 'https://download.pytorch.org/models/vgg16-397923af.pth'
-```
-This creates the needed directories and downloads the pre-trained VGG16 parameters and 8 images of light houses from Wikimedia Commons into the required label-directory structure for the Imagenet dataset in Pytorch.
-
-The `feed_forward.py` example may then be run using:
-```shell
-$ .venv/bin/python feed_forward.py \
-    data/lighthouses \
-    'results/vgg16_epsilon_gamma_box_{sample:02d}.png' \
-    --inputs 'results/vgg16_input_{sample:02d}.png' \
-    --parameters params/vgg16-397923af.pth \
-    --model vgg16 \
-    --composite epsilon_gamma_box \
-    --relevance-norm symmetric \
-    --cmap coldnhot
-```
-which computes the LRP heatmaps according to the `epsilon_gamma_box` rule and
-stores them in `results`, along with the respective input images. Other
-possible composites that can be passed to `--composites` are, e.g.,
-`epsilon_plus`, `epsilon_alpha2_beta1_flat`, `guided_backprop`,
-`excitation_backprop`.
-
-The resulting heatmaps may look like the following:
-![beacon heatmaps](share/img/beacon_vgg16_epsilon_gamma_box.png)
-
-Alternatively, heatmaps for SmoothGrad with absolute relevances may be computed
-by omitting `--composite` and supplying `--attributor`:
-```shell
-$ .venv/bin/python feed_forward.py \
-    data/lighthouses \
-    'results/vgg16_smoothgrad_{sample:02d}.png' \
-    --inputs 'results/vgg16_input_{sample:02d}.png' \
-    --parameters params/vgg16-397923af.pth \
-    --model vgg16 \
-    --attributor smoothgrad \
-    --relevance-norm absolute \
-    --cmap hot
-```
-For Integrated Gradients, `--attributor integrads` may be provided.
-
-Heatmaps for Occlusion Analysis with unaligned relevances may be computed by
-executing:
-```shell
-$ .venv/bin/python feed_forward.py \
-    data/lighthouses \
-    'results/vgg16_occlusion_{sample:02d}.png' \
-    --inputs 'results/vgg16_input_{sample:02d}.png' \
-    --parameters params/vgg16-397923af.pth \
-    --model vgg16 \
-    --attributor occlusion \
-    --relevance-norm unaligned \
-    --cmap hot
-```
-
-## Example Heatmaps
-Heatmaps of various attribution methods for VGG16 and ResNet50, all generated using
-[`share/example/feed_forward.py`](share/example/feed_forward.py), can be found below.
+### More Example Heatmaps
+More heatmaps of various attribution methods for VGG16 and ResNet50, all
+generated using
+[`share/example/feed_forward.py`](share/example/feed_forward.py), can be found
+below.
 
 <details>
   <summary>Heatmaps for VGG16</summary>
@@ -197,21 +127,9 @@ Heatmaps of various attribution methods for VGG16 and ResNet50, all generated us
 </details>
 
 ## Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions on how to contribute.
 
-### Code Style
-We use [PEP8](https://www.python.org/dev/peps/pep-0008) with a line-width of 120 characters. For
-docstrings we use [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html).
-
-We use [`flake8`](https://pypi.org/project/flake8/) for quick style checks and
-[`pylint`](https://pypi.org/project/pylint/) for thorough style checks.
-
-### Testing
-Tests are written using [Pytest](https://docs.pytest.org) and executed
-in a separate environment using [Tox](https://tox.readthedocs.io/en/latest/).
-
-A full style check and all tests can be run by simply calling `tox` in the repository root.
-
-### Documentation
-The documentation is written using [Sphinx](https://www.sphinx-doc.org). It can be built at
-`docs/build` using the respective Tox environment with `tox -e docs`. To rebuild the full
-documentation, `tox -e docs -- -aE` can be used.
+## License
+Zennit is licensed under the GNU LESSER GENERAL PUBLIC LICENSE VERSION 3 OR
+LATER -- see the [LICENSE](LICENSE), [COPYING](COPYING) and
+[COPYING.LESSER](COPYING.LESSER) files for details.


### PR DESCRIPTION
- remove the example script from README.md, which is already present in
  the documentation, for a cleaner look
- move contributing guide to CONTRIBUTING.md and add a link in README.md
- add a short introduction for contributing
- add git commit instructions
- add some instructions to writing tutorials
- add a sentence stating that github actions is used
- add a short license section to the end of the readme