### PR TITLE
Composites/Rules: Zero Bias Option

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -66,6 +66,9 @@ The following computes LRP relevance using the ``EpsilonPlusFlat`` composite:
     # create a composite instance
     composite = EpsilonPlusFlat()
 
+    # use the following instead to ignore bias for the relevance
+    # composite = EpsilonPlusFlat(zero_params='bias')
+
     # make sure the input requires a gradient
     input.requires_grad = True
 
@@ -122,7 +125,7 @@ may be combined with propagation-based (composite) approaches.
         # gradient/ relevance wrt. output/class 7
         output, relevance = attributor(input, torch.eye(10)[[7]])
 
-    print('SmoothGrad:', relevance)
+   print('SmoothGrad:', relevance)
 
 More information on attributors can be found in :doc:`/how-to/use-attributors`
 and :doc:`/how-to/write-custom-attributors`.
@@ -148,8 +151,7 @@ be simply supplied when instantiating a composite:
    # create the canonizers
    canonizers = [VGGCanonizer()]
    # EpsilonGammaBox needs keyword arguments 'low' and 'high'
-   high = torch.full_like(input, 4)
-   composite = EpsilonGammaBox(low=-high, high=high, canonizers=canonizers)
+   composite = EpsilonGammaBox(low=-3., high=3., canonizers=canonizers)
 
    with Gradient(model, composite) as attributor:
         # gradient/ relevance wrt. output/class 0
@@ -272,6 +274,7 @@ The ``feed_forward.py`` example can then be run using:
        --parameters params/vgg16-397923af.pth \
        --model vgg16 \
        --composite epsilon_gamma_box \
+       --no-bias \
        --relevance-norm symmetric \
        --cmap coldnhot
 
@@ -279,6 +282,7 @@ which computes the lrp heatmaps according to the ``epsilon_gamma_box`` rule and
 stores them in results, along with the respective input images. Other possible
 composites that can be passed to ``--composites`` are, e.g., ``epsilon_plus``,
 ``epsilon_alpha2_beta1_flat``, ``guided_backprop``, ``excitation_backprop``.
+The bias can be ignored in the LRP-computation by passing ``--no-bias``.
 
 
 ..

--- a/share/example/feed_forward.py
+++ b/share/example/feed_forward.py
@@ -72,6 +72,7 @@ class AllowEmptyClassImageFolder(ImageFolder):
 @click.option('--n-outputs', type=int, default=1000)
 @click.option('--cpu/--gpu', default=True)
 @click.option('--shuffle/--no-shuffle', default=False)
+@click.option('--with-bias/--no-bias', default=True)
 @click.option('--relevance-norm', type=click.Choice(['symmetric', 'absolute', 'unaligned']), default='symmetric')
 @click.option('--cmap', type=click.Choice(list(CMAPS)), default='coldnhot')
 @click.option('--level', type=float, default=1.0)
@@ -89,6 +90,7 @@ def main(
     n_outputs,
     cpu,
     shuffle,
+    with_bias,
     cmap,
     level,
     relevance_norm,
@@ -158,6 +160,17 @@ def main(
             # the highest and lowest pixel values for the ZBox rule
             composite_kwargs['low'] = norm_fn(torch.zeros(*shape, device=device))
             composite_kwargs['high'] = norm_fn(torch.ones(*shape, device=device))
+
+        # provide the name 'bias' in zero_params if no bias should be used to compute the relevance
+        if not with_bias and composite_name in [
+            'epsilon_gamma_box',
+            'epsilon_plus',
+            'epsilon_alpha2_beta1',
+            'epsilon_plus_flat',
+            'epsilon_alpha2_beta1_flat',
+            'excitation_backprop',
+        ]:
+            composite_kwargs['zero_params'] = ['bias']
 
         # use torchvision specific canonizers, as supplied in the MODELS dict
         composite_kwargs['canonizers'] = [MODELS[model_name][1]()]

--- a/src/zennit/composites.py
+++ b/src/zennit/composites.py
@@ -167,13 +167,14 @@ class EpsilonGammaBox(SpecialFirstLayerMapComposite):
     gamma: float
         Gamma parameter for the gamma rule.
     '''
-    def __init__(self, low, high, epsilon=1e-6, gamma=0.25, canonizers=None):
+    def __init__(self, low, high, epsilon=1e-6, gamma=0.25, zero_params=None, canonizers=None):
+        rule_kwargs = {'zero_params': zero_params}
         layer_map = LAYER_MAP_BASE + [
-            (Convolution, Gamma(gamma=gamma)),
-            (torch.nn.Linear, Epsilon(epsilon=epsilon)),
+            (Convolution, Gamma(gamma=gamma, **rule_kwargs)),
+            (torch.nn.Linear, Epsilon(epsilon=epsilon, **rule_kwargs)),
         ]
         first_map = [
-            (Convolution, ZBox(low, high))
+            (Convolution, ZBox(low=low, high=high, **rule_kwargs))
         ]
         super().__init__(layer_map, first_map, canonizers=canonizers)
 
@@ -188,10 +189,11 @@ class EpsilonPlus(LayerMapComposite):
     epsilon: float
         Epsilon parameter for the epsilon rule.
     '''
-    def __init__(self, epsilon=1e-6, canonizers=None):
+    def __init__(self, epsilon=1e-6, zero_params=None, canonizers=None):
+        rule_kwargs = {'zero_params': zero_params}
         layer_map = LAYER_MAP_BASE + [
-            (Convolution, ZPlus()),
-            (torch.nn.Linear, Epsilon(epsilon=epsilon)),
+            (Convolution, ZPlus(**rule_kwargs)),
+            (torch.nn.Linear, Epsilon(epsilon=epsilon, **rule_kwargs)),
         ]
         super().__init__(layer_map, canonizers=canonizers)
 
@@ -206,10 +208,11 @@ class EpsilonAlpha2Beta1(LayerMapComposite):
     epsilon: float
         Epsilon parameter for the epsilon rule.
     '''
-    def __init__(self, epsilon=1e-6, canonizers=None):
+    def __init__(self, epsilon=1e-6, zero_params=None, canonizers=None):
+        rule_kwargs = {'zero_params': zero_params}
         layer_map = LAYER_MAP_BASE + [
-            (Convolution, AlphaBeta(alpha=2, beta=1)),
-            (torch.nn.Linear, Epsilon(epsilon=epsilon)),
+            (Convolution, AlphaBeta(alpha=2, beta=1, **rule_kwargs)),
+            (torch.nn.Linear, Epsilon(epsilon=epsilon, **rule_kwargs)),
         ]
         super().__init__(layer_map, canonizers=canonizers)
 
@@ -224,13 +227,14 @@ class EpsilonPlusFlat(SpecialFirstLayerMapComposite):
     epsilon: float
         Epsilon parameter for the epsilon rule.
     '''
-    def __init__(self, epsilon=1e-6, canonizers=None):
+    def __init__(self, epsilon=1e-6, zero_params=None, canonizers=None):
+        rule_kwargs = {'zero_params': zero_params}
         layer_map = LAYER_MAP_BASE + [
-            (Convolution, ZPlus()),
-            (torch.nn.Linear, Epsilon(epsilon=epsilon)),
+            (Convolution, ZPlus(**rule_kwargs)),
+            (torch.nn.Linear, Epsilon(epsilon=epsilon, **rule_kwargs)),
         ]
         first_map = [
-            (Linear, Flat())
+            (Linear, Flat(**rule_kwargs))
         ]
         super().__init__(layer_map, first_map, canonizers=canonizers)
 
@@ -245,13 +249,14 @@ class EpsilonAlpha2Beta1Flat(SpecialFirstLayerMapComposite):
     epsilon: float
         Epsilon parameter for the epsilon rule.
     '''
-    def __init__(self, epsilon=1e-6, canonizers=None):
+    def __init__(self, epsilon=1e-6, zero_params=None, canonizers=None):
+        rule_kwargs = {'zero_params': zero_params}
         layer_map = LAYER_MAP_BASE + [
-            (Convolution, AlphaBeta(alpha=2, beta=1)),
-            (torch.nn.Linear, Epsilon(epsilon=epsilon)),
+            (Convolution, AlphaBeta(alpha=2, beta=1, **rule_kwargs)),
+            (torch.nn.Linear, Epsilon(epsilon=epsilon, **rule_kwargs)),
         ]
         first_map = [
-            (Linear, Flat())
+            (Linear, Flat(**rule_kwargs))
         ]
         super().__init__(layer_map, first_map, canonizers=canonizers)
 
@@ -283,10 +288,11 @@ class GuidedBackprop(LayerMapComposite):
 @register_composite('excitation_backprop')
 class ExcitationBackprop(LayerMapComposite):
     '''An explicit composite implementing the ExcitationBackprop :cite:p:`zhang2016top`.'''
-    def __init__(self, canonizers=None):
+    def __init__(self, zero_params=None, canonizers=None):
+        rule_kwargs = {'zero_params': zero_params}
         layer_map = [
             (Sum, Norm()),
             (AvgPool, Norm()),
-            (Linear, ZPlus()),
+            (Linear, ZPlus(**rule_kwargs)),
         ]
         super().__init__(layer_map, canonizers=canonizers)

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -15,9 +15,7 @@ def ishookcopy(hook, hook_template):
                 'param_modifiers',
                 'output_modifiers',
                 'gradient_mapper',
-                'reducer',
-                'param_keys',
-                'require_params'
+                'param_kwargs',
             )
         )
     return isinstance(hook, type(hook_template))


### PR DESCRIPTION
- add a straight forward approach to zero only the bias
- this is done by implementing a more general approach to give the
  option to zero out any parameter
- mod_params and BasicHook now accept a keyword argument 'zero_params',
  which will set all parameters with a name equal to or in zero_params
  to zero
- this is implemented by wrapping the supplied modifier in mod_params
  using zennit.core.zero_wrap with a function that will check for the
  name, and if matching, not pass the tensor to the real modifier, but
  return zeros like the input tensor
- supporting rules are Epsilon, Gamma, ZPlus, AlphaBeta, ZBox, WSquare
  and Flat
- all composites with supporting rules now also have the keyword
  argument 'zero_params', which will be applied to all rules
- BasicHook now stores the attributes param_keys, require_params and the
  new zero_params in a single dictionary attribute param_kwargs; tests
  were modified to support this change
- BasicHook.copy now keeps the type for copied subclasses; the subclass
  __init__ however is never called, therefore setting custom attributes
  etc. in the __init__ will require a custom .copy method
- updated tests for the appropriate rules and the modified mod_params
- updated the example script share/example/feed_forward.py to specify
  whether or not the bias should be used
- added usage of zero_params to documentation in getting-started and
  how-to for rules, composites and canonizers