### PR TITLE
Draft: Composites: Cooperative LayerMapComposite

### DIFF
--- a/src/zennit/types.py
+++ b/src/zennit/types.py
@@ -86,6 +86,18 @@ class AvgPool(metaclass=SubclassMeta):
     )
 
 
+class MaxPool(metaclass=SubclassMeta):
+    '''Abstract base class that describes max-pooling modules.'''
+    __subclass__ = (
+        torch.nn.modules.pooling.MaxPool1d,
+        torch.nn.modules.pooling.MaxPool2d,
+        torch.nn.modules.pooling.MaxPool3d,
+        torch.nn.modules.pooling.AdaptiveMaxPool1d,
+        torch.nn.modules.pooling.AdaptiveMaxPool2d,
+        torch.nn.modules.pooling.AdaptiveMaxPool3d,
+    )
+
+
 class Activation(metaclass=SubclassMeta):
     '''Abstract base class that describes activation modules.'''
     __subclass__ = (

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -42,12 +42,15 @@ def test_composite_layer_map_registered(layer_map_composite, model_vision):
     '''Tests whether the explicit LayerMapComposites register and unregister their rules correctly.'''
     errors = []
     with layer_map_composite.context(model_vision):
-        for child, (dtype, hook_template) in product(model_vision.modules(), layer_map_composite.layer_map):
-            if isinstance(child, dtype) and not check_hook_registered(child, hook_template):
-                errors.append((
-                    '{} is of {} but {} is not registered!',
-                    (child, dtype, hook_template),
-                ))
+        for child in model_vision.modules():
+            for dtype, hook_template in layer_map_composite.layer_map:
+                if isinstance(child, dtype):
+                    if not check_hook_registered(child, hook_template):
+                        errors.append((
+                            '{} is first of {} but {} is not registered!',
+                            (child, dtype, hook_template),
+                        ))
+                    break
 
     if not verify_no_hooks(model_vision):
         errors.append(('Model has hooks registered after composite was removed!', ()))
@@ -72,17 +75,20 @@ def test_composite_special_first_layer_map_registered(special_first_layer_map_co
     with special_first_layer_map_composite.context(model_vision):
         if special_first_layer is not None and not check_hook_registered(special_first_layer, special_first_template):
             errors.append((
-                'Special first layer {} is of {} but {} is not registered!',
+                'Special first layer {} is first of {} but {} is not registered!',
                 (special_first_layer, special_first_dtype, special_first_template)
             ))
 
         children = (child for child in model_vision.modules() if child is not special_first_layer)
-        for child, (dtype, hook_template) in product(children, special_first_layer_map_composite.layer_map):
-            if isinstance(child, dtype) and not check_hook_registered(child, hook_template):
-                errors.append((
-                    '{} is of {} but {} is not registered!',
-                    (child, dtype, hook_template),
-                ))
+        for child in children:
+            for dtype, hook_template in special_first_layer_map_composite.layer_map:
+                if isinstance(child, dtype):
+                    if not check_hook_registered(child, hook_template):
+                        errors.append((
+                            '{} is first of {} but {} is not registered!',
+                            (child, dtype, hook_template),
+                        ))
+                    break
 
     if not verify_no_hooks(model_vision):
         errors.append(('Model has hooks registered after composite was removed!', ()))
@@ -93,14 +99,16 @@ def test_composite_special_first_layer_map_registered(special_first_layer_map_co
 def test_composite_name_map_registered(name_map_composite, model_vision):
     '''Tests whether the constructed NameMapComposites register and unregister their rules correctly.'''
     errors = []
-    setups = product(model_vision.named_modules(), name_map_composite.name_map)
     with name_map_composite.context(model_vision):
-        for (name, child), (names, hook_template) in setups:
-            if name in names and not check_hook_registered(child, hook_template):
-                errors.append(
-                    '{} is in name map for {}, but is not registered!',
-                    (name, hook_template),
-                )
+        for name, child in model_vision.named_modules():
+            for names, hook_template in name_map_composite.name_map:
+                if name in names:
+                    if not check_hook_registered(child, hook_template):
+                        errors.append(
+                            '{} is first in name map for {}, but is not registered!',
+                            (name, hook_template),
+                        )
+                    break
 
     if not verify_no_hooks(model_vision):
         errors.append(('Model has hooks registered after composite was removed!', ()))


### PR DESCRIPTION
## Composites: Cooperative LayerMapComposite

- add the parameter `layer_map` to built-in subclasses of
  LayerMapComposite, which will be prepended to the composite's
  `layer_map`
- add the parameter `layer_map` and `first_map` to built-in subclasses
  of SpecialFirstLayerMapComposite, which will be prepended to the
  composites `layer_map` and `first_map` respectively
- this is done to let the user easily introduce small changes to the
  built-in composites, for example to add rules for missing layers, or
  change the behavior for existing modules
- the most important use-case for this is adding a mapping for `MaxPool` layers
  to use another rule without the need to implement a full composite
- for this use-case, also add the abstract type `MaxPool`

## Tests: Cooperative LayerMapComposite

- added tests for built-in cooperative LayerMapComposites
- built-in composites now get cooperative variations for tests in
  conftest.py
- these variations get custom rules `PassClone` and `GradClone`
- the registered rule for each module is now checked only for the first
  match in the module_map, which would previously lead to errors when
  one module had more than one matching rule

## Docs: Cooperative LayerMapComposite

- add documentation for cooperative LayerMapComposite subtypes
- add subsections to how-to/use-rules-composites-and-canonizers
  Composite