### PR TITLE
MixedComposite and NameLayerMapComposite for combining arbitrary Composites

### DIFF
--- a/docs/source/how-to/use-rules-composites-and-canonizers.rst
+++ b/docs/source/how-to/use-rules-composites-and-canonizers.rst
@@ -450,7 +450,7 @@ This creates a composite which will in turn create a
 The created composite will first try to match for a specific layer
 name by applying the mapping from the instantiated
 :py:class:`~zennit.composites.NameMapComposite`.
-If None are found, the matching process continues with the
+If none are found, the matching process continues with the
 :py:class:`~zennit.composites.LayerMapComposite`.
 
 
@@ -466,8 +466,8 @@ If None are found, the matching process continues with the
 This creates a composite which will first try to match for a specific layer
 name by applying the respective mappings of each composite in the given list.
 In the example above, if a layer name match is successful, it registers the
-hook from `composite_name_map`. If no matching name found, the matching process
-continues with `composite_special_first_layer`.
+hook from ``composite_name_map``. If no matching name found, the matching process
+continues with ``composite_special_first_layer``.
 
 
 .. _cooperative-layermapcomposites:

--- a/src/zennit/composites.py
+++ b/src/zennit/composites.py
@@ -1,3 +1,4 @@
+# This file is part of Zennit
 # Copyright (C) 2019-2021 Christopher J. Anders
 #
 # zennit/composites.py

--- a/src/zennit/composites.py
+++ b/src/zennit/composites.py
@@ -1,4 +1,3 @@
-# This file is part of Zennit
 # Copyright (C) 2019-2021 Christopher J. Anders
 #
 # zennit/composites.py
@@ -55,7 +54,8 @@ class LayerMapComposite(Composite):
         Returns
         -------
         obj:`Hook` or None
-            The hook found with the module type in the given layer map, or None if no applicable hook was found.
+            The hook found with the module type in the given layer map,
+            or None if no applicable hook was found.
         '''
         return next((hook for types, hook in self.layer_map if isinstance(module, types)), None)
 
@@ -92,8 +92,9 @@ class SpecialFirstLayerMapComposite(LayerMapComposite):
         Returns
         -------
         obj:`Hook` or None
-            The hook found with the module type in the given layer map, in the first layer map if this was the first
-            layer, or None if no applicable hook was found.
+            The hook found with the module type in the given layer map,
+            in the first layer map if this was the first layer,
+            or None if no applicable hook was found.
         '''
         if not ctx.get('first_layer_visited', False):
             for types, hook in self.first_map:
@@ -105,7 +106,7 @@ class SpecialFirstLayerMapComposite(LayerMapComposite):
 
 
 class NameMapComposite(Composite):
-    '''A Composite for which hooks are specified by a mapping from module types to hooks.
+    '''A Composite for which hooks are specified by a mapping from module names to hooks.
 
     Parameters
     ----------
@@ -134,9 +135,84 @@ class NameMapComposite(Composite):
         Returns
         -------
         obj:`Hook` or None
-            The hook found with the module type in the given name map, or None if no applicable hook was found.
+            The hook found with the module name in the given name map, or None if no applicable
+            hook was found.
         '''
         return next((hook for names, hook in self.name_map if name in names), None)
+
+
+class MixedComposite(Composite):
+    '''A Composite for which hooks are specified by a list of composites.
+
+    Each composite defines a mapping from layer property to a specific Hook.
+    The list order of composites defines their matching order.
+
+    Parameters
+    ----------
+    composites: `list[Composite]`
+        A list of Composites. The list order of composites defines their matching order.
+    canonizers: list[:py:class:`zennit.canonizers.Canonizer`], optional
+        List of canonizer instances to be applied before applying hooks.
+    '''
+    def __init__(self, composites, canonizers=None):
+        if canonizers is None:
+            canonizers = []
+        self.composites = composites
+        super().__init__(
+            module_map=self.mapping,
+            canonizers=sum([composite.canonizers for composite in composites], canonizers)
+        )
+
+    def mapping(self, ctx, name, module):
+        '''Get the appropriate hook given a list of composites.
+
+        Parameters
+        ----------
+        ctx: dict
+            A context dictionary to keep track of previously registered hooks.
+        name: str
+            Name of the module.
+        module: obj:`torch.nn.Module`
+            Instance of the module to find a hook for.
+
+        Returns
+        -------
+        obj:`Hook` or None
+            The hook found by the first match in the composite list,
+            or None if no applicable hook was found.
+        '''
+        # create a context for each of the sub-composites if ctx is empty
+        if not ctx:
+            ctx.update({composite: {} for composite in self.composites})
+
+        # create list of hooks by evaluating module maps of all given composites
+        hooks = [composite.module_map(ctx[composite], name, module) for composite in self.composites]
+
+        # return first hook that is not None, if there isn't any, return None
+        return next((hook for hook in hooks if hook is not None), None)
+
+
+class NameLayerMapComposite(MixedComposite):
+    '''A Composite for which hooks are specified by both a mapping from
+    module names and module types to hooks.
+
+    This implicitly creates instances of NameMapComposite and LayerMapComposite.
+    The layer-name mapping will be matched before the layer-type mapping.
+
+    Parameters
+    ----------
+    name_map: `list[tuple[tuple[str, ...], Hook]]`
+        A mapping as a list of tuples, with a tuple of applicable module names and a Hook.
+    layer_map: list[tuple[tuple[torch.nn.Module, ...], Hook]], optional
+        A mapping as a list of tuples, with a tuple of applicable module types and a Hook.
+    canonizers: list[:py:class:`zennit.canonizers.Canonizer`], optional
+        List of canonizer instances to be applied before applying hooks.
+    '''
+    def __init__(self, name_map=None, layer_map=None, canonizers=None):
+        super().__init__(composites=[
+            NameMapComposite(name_map=name_map),
+            LayerMapComposite(layer_map=layer_map),
+        ], canonizers=canonizers)
 
 
 COMPOSITES = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,13 @@ from helpers import prodict, one_hot_max
 
 from zennit.attribution import identity
 from zennit.core import Composite, Hook
-from zennit.composites import COMPOSITES, NameMapComposite, LayerMapComposite, SpecialFirstLayerMapComposite
+from zennit.composites import COMPOSITES
 from zennit.composites import EpsilonGammaBox
+from zennit.composites import LayerMapComposite
+from zennit.composites import MixedComposite
+from zennit.composites import NameLayerMapComposite
+from zennit.composites import NameMapComposite
+from zennit.composites import SpecialFirstLayerMapComposite
 from zennit.types import Linear as AnyLinear, Activation
 
 
@@ -231,6 +236,24 @@ def name_map_composite(request, model_vision, layer_map_composite):
                 break
     name_map = [(tuple(value), key) for key, value in rule_map.items()]
     return NameMapComposite(name_map=name_map)
+
+
+@pytest.fixture(scope='session')
+def mixed_composite(request, model_vision, name_map_composite, special_first_layer_map_composite):
+    '''Fixture to create NameLayerMapComposites based on an explicit
+    NameMapComposite and SpecialFirstLayerMapComposites.'''
+    composites = [name_map_composite, special_first_layer_map_composite]
+    return MixedComposite(composites)
+
+
+@pytest.fixture(scope='session')
+def name_layer_map_composite(request, model_vision, name_map_composite, layer_map_composite):
+    '''Fixture to create NameLayerMapComposites based on an explicit
+    NameMapComposite and LayerMapComposite.'''
+    return NameLayerMapComposite(
+        name_map=name_map_composite.name_map,
+        layer_map=layer_map_composite.layer_map,
+    )
 
 
 @pytest.fixture(scope='session', params=[alexnet, vgg11, resnet18])

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -119,8 +119,7 @@ def test_composite_mixed_registered(mixed_composite, model_vision):
     '''Tests whether the constructed MixedComposites register and unregister their rules correctly.'''
     errors = []
 
-    name_map_composite = mixed_composite.composites[0]
-    special_first_layer_map_composite = mixed_composite.composites[1]
+    name_map_composite, special_first_layer_map_composite = mixed_composite.composites
 
     try:
         special_first_layer, special_first_template, special_first_dtype = next(
@@ -178,19 +177,23 @@ def test_composite_name_layer_map_registered(name_layer_map_composite, model_vis
     '''Tests whether the constructed NameLayerMapComposites register and unregister their rules correctly.'''
     errors = []
 
-    name_map_composite = name_layer_map_composite.composites[0]
-    layer_map_composite = name_layer_map_composite.composites[1]
+    name_map_composite, layer_map_composite = name_layer_map_composite.composites
 
     with name_layer_map_composite.context(model_vision):
         for name, child in model_vision.named_modules():
             for names, hook_template in name_map_composite.name_map:
+                has_matched_name_map = False
                 if name in names:
+                    has_matched_name_map = True
                     if not check_hook_registered(child, hook_template):
                         errors.append((
                             '{} is first in name map for {}, but is not registered!',
                             (name, hook_template),
                         ))
                     break
+
+            if has_matched_name_map:
+                continue
 
             for dtype, hook_template in layer_map_composite.layer_map:
                 if isinstance(child, dtype):


### PR DESCRIPTION
This way it is possible to specify a fallback layer map if we want to apply more general rules to the remaining layers.

The parameter is optional. If None is passed, there's no change in functionality.
If a layer_map list is passed with the same format as for the LayerMapComposite, then this will be used as a fallback if there's no hook for this specific layer name.

Just an example, where it's possible to set one Hook for the first two convolutional layers, and a different one for the remaining ones:

```
cmp = NameMapComposite(
    name_map=[(('conv_1, 'conv_2'), Flat()],
    layer_map=[((zennit.types.Convolution, ), AlphaBeta())],
)
```

I hope you deem this to be a useful addition to this package.