### PR TITLE
Composite: fix passing of beta_smooth value

### DIFF
--- a/src/zennit/composites.py
+++ b/src/zennit/composites.py
@@ -494,6 +494,6 @@ class BetaSmooth(LayerMapComposite):
             layer_map = []
 
         layer_map = layer_map + [
-            (torch.nn.ReLU, ReLUBetaSmooth()),
+            (torch.nn.ReLU, ReLUBetaSmooth(beta_smooth=beta_smooth)),
         ]
         super().__init__(layer_map=layer_map, canonizers=canonizers)


### PR DESCRIPTION
The BetaSmooth composite did not pass the beta_smooth value to the ReLUBetaSmooth hook constructor resulting in beta_smooth==10 at all times.