### PR TITLE
Docs: Gradient.forward() input not optional

### DIFF
--- a/src/zennit/attribution.py
+++ b/src/zennit/attribution.py
@@ -271,7 +271,7 @@ class Gradient(Attributor):
         ----------
         input: :py:obj:`torch.Tensor`
             Input for the model, and wrt. compute the attribution.
-        attr_output: :py:obj:`torch.Tensor` or callable, optional
+        attr_output_fn: :py:obj:`torch.Tensor` or callable
             The output attribution function of the model's output.
 
         Returns


### PR DESCRIPTION
- removed "optional" for attr_output since it seems to be required
- changed attr_output to attr_output_fn to match variable name