### PR TITLE
CI: Fix flake8 update: 3-digit error codes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,11 +56,11 @@ commands =
     pylint --rcfile=pylintrc --output-format=parseable {toxinidir}/src/zennit {toxinidir}/tests
 
 [flake8]
-# R0902 Too many instance attributes
-# R0913 Too many arguments
-# R0914 Too many local variables
+# R902 Too many instance attributes
+# R913 Too many arguments
+# R914 Too many local variables
 # W503  Line-break before binary operator
-ignore = R0902,R0913,R0914,W503
+ignore = R902,R913,R914,W503
 
 exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
 


### PR DESCRIPTION
- fixed the ignore option in tox.ini under flake8, which expects in the most recent version that all codes only have 3 digits