### PR TITLE
Canonizers/ParamMod: Fix Gradients for Parameters

### DIFF
--- a/src/zennit/core.py
+++ b/src/zennit/core.py
@@ -324,12 +324,12 @@ class ParamMod:
                     param = getattr(module, key)
                     if param is not None:
                         stored_params[key] = param
-                        setattr(module, key, torch.nn.Parameter(modifier(param.data, key)))
+                        object.__setattr__(module, key, modifier(param.data, key))
 
             yield module
         finally:
             for key, value in stored_params.items():
-                setattr(module, key, value)
+                object.__setattr__(module, key, value)
 
 
 def collect_leaves(module):


### PR DESCRIPTION
- when computing the gradient wrt. parameters on models canonized with MergeBatchNorm, the gradient would previously not be computed with respect to the original parameters, as they were detached from the graph/overwritten
- now, the parameters of the linear module are explicitly set to tensors which depend on the original parameters, leading to the correct computation of gradients
- set the batch-norm's `eps` to zero and store the old value, thus fixing the slightly different values
- ParmMod: use object.__setattr__ to overwrite the module attributes instead of setting a new torch.nn.Parameter to correctly track the gradient wrt. the original parameter
