### PR TITLE
Fix small typo in image-classification-vgg-resnet.ipynb

### DIFF
--- a/docs/source/tutorial/image-classification-vgg-resnet.ipynb
+++ b/docs/source/tutorial/image-classification-vgg-resnet.ipynb
@@ -171,7 +171,7 @@
     "## 2. VGG11 without BatchNorm\n",
     "\n",
     "We start with VGG11 without BatchNorm.\n",
-    "First, we initialize the VGG16 model and optionally load the hyperparameters.\n",
+    "First, we initialize the VGG11 model and optionally load the hyperparameters.\n",
     "Set `weights='IMAGENET1K_V1'` to use the pre-trained model instead of the random\n",
     "one:"
    ]


### PR DESCRIPTION
It seems there is a small typo in the tutorial notebook.