### PR TITLE
remove nn.MultiheadAttention from Activation types.py

### DIFF
--- a/src/zennit/types.py
+++ b/src/zennit/types.py
@@ -108,7 +108,6 @@ class Activation(metaclass=SubclassMeta):
         torch.nn.modules.activation.Hardswish,
         torch.nn.modules.activation.LeakyReLU,
         torch.nn.modules.activation.LogSigmoid,
-        torch.nn.modules.activation.MultiheadAttention,
         torch.nn.modules.activation.PReLU,
         torch.nn.modules.activation.ReLU,
         torch.nn.modules.activation.ReLU6,


### PR DESCRIPTION
Bugfix: Zennit assigns per default the Pass rule to the nn.MultiheadAttention layer. However, the MultiheadAttention module requires another rule.