### PR TITLE
Add torchvision.ops.FrozenBatchNorm2d to types

### DIFF
--- a/src/zennit/types.py
+++ b/src/zennit/types.py
@@ -17,7 +17,7 @@
 # along with this library. If not, see <https://www.gnu.org/licenses/>.
 '''Type definitions for convenience.'''
 import torch
-
+import torchvision
 
 class SubclassMeta(type):
     '''Meta class to bundle multiple subclasses.'''
@@ -71,6 +71,7 @@ class BatchNorm(metaclass=SubclassMeta):
         torch.nn.modules.batchnorm.BatchNorm1d,
         torch.nn.modules.batchnorm.BatchNorm2d,
         torch.nn.modules.batchnorm.BatchNorm3d,
+        torchvision.ops.FrozenBatchNorm2d,
     )
 
 


### PR DESCRIPTION
torchvision.ops.FrozenBatchNorm2d is part of many SOTA models and contains the same attributes/buffers as the torch.nn.BatchNorm2d module.
Hence, it can be canonized with the existing SequentialMergeBatchNorm class. 