### PR TITLE
Docs: Pin nbconvert < 7.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
             'sphinxcontrib.datatemplates>=0.9.0',
             'sphinxcontrib.bibtex>=2.4.1',
             'nbsphinx>=0.8.8',
+            'nbconvert<7.14',  # see https://github.com/jupyter/nbconvert/issues/2092
             'ipykernel>=6.13.0',
         ],
         'tests': [


### PR DESCRIPTION
- pin nbconvert due to directive errors in sphinx caused by nbconvert >= 7.14