### PR TITLE
Docstring: Fix issues highlighted by pydoclint

### DIFF
--- a/src/zennit/attribution.py
+++ b/src/zennit/attribution.py
@@ -50,8 +50,8 @@ def identity(obj):
     obj : object
         Any object which will be returned.
 
-    Result
-    ------
+    Returns
+    -------
     obj : object
         The original input argument ``obj``.
 
@@ -137,6 +137,18 @@ class Attributor(metaclass=ABCMeta):
     def __exit__(self, exc_type, exc_value, traceback):
         '''Remove the composite, if provided.
 
+        Parameters
+        ----------
+        exc_type : type or None
+            The type of the exception that caused the context to be exited.
+            `None` if the context was exited without an exception.
+        exc_value : Exception or None
+            The exception instance that caused the context to be exited.
+            `None` if the context was exited without an exception.
+        traceback : TracebackType or None
+            The traceback object associated with the exception.
+            `None` if the context was exited without an exception.
+
         Returns
         -------
         False
@@ -197,7 +209,7 @@ class Attributor(metaclass=ABCMeta):
         ----------
         input: :py:obj:`torch.Tensor`
             Input for the model, and wrt. compute the attribution
-        attr_output: :py:obj:`torch.Tensor` or callable, optional
+        attr_output_fn: :py:obj:`torch.Tensor` or callable, optional
             The output attribution function of the model's output.
         '''
 
@@ -240,7 +252,7 @@ class Gradient(Attributor):
         ----------
         input: :py:obj:`torch.Tensor`
             Input for the model.
-        attr_output: :py:obj:`torch.Tensor` or callable, optional
+        attr_output_fn: :py:obj:`torch.Tensor` or callable, optional
             The output attribution function of the model's output.
 
         Returns
@@ -342,7 +354,7 @@ class SmoothGrad(Gradient):
         ----------
         input: :py:obj:`torch.Tensor`
             Input for the model, and wrt. compute the attribution.
-        attr_output: :py:obj:`torch.Tensor` or callable, optional
+        attr_output_fn: :py:obj:`torch.Tensor` or callable, optional
             The output attribution function of the model's output.
 
         Returns
@@ -437,7 +449,7 @@ class IntegratedGradients(Gradient):
         ----------
         input: :py:obj:`torch.Tensor`
             Input for the model, and wrt. compute the attribution.
-        attr_output: :py:obj:`torch.Tensor` or callable, optional
+        attr_output_fn: :py:obj:`torch.Tensor` or callable, optional
             The output attribution function of the model's output.
 
         Returns
@@ -493,6 +505,11 @@ class Occlusion(Attributor):
         the window will only stride over the n-last dimensions, where n is the length of the tuple.
         `stride` must have the same length as `window`.
 
+    Raises
+    ------
+    TypeError
+        If the type of `window` or `stride` is wrong.
+
     '''
     def __init__(self, model, composite=None, attr_output=None, occlusion_fn=None, window=8, stride=8):
         def typecheck(obj):
@@ -535,7 +552,7 @@ class Occlusion(Attributor):
         ----------
         input: :py:obj:`torch.Tensor`
             Input for the model, and wrt. compute the attribution.
-        attr_output: :py:obj:`torch.Tensor` or callable, optional
+        attr_output_fn: :py:obj:`torch.Tensor` or callable, optional
             The output attribution function of the model's output.
 
         Returns

--- a/src/zennit/canonizers.py
+++ b/src/zennit/canonizers.py
@@ -53,7 +53,14 @@ class Canonizer(metaclass=ABCMeta):
         '''Revert the changes introduces by this canonizer.'''
 
     def copy(self):
-        '''Return a copy of this instance.'''
+        '''Return a copy of this instance.
+
+        Returns
+        -------
+        :py:obj:`Canonizer`
+            A copy of this canonizer.
+
+        '''
         return self.__class__()
 
 
@@ -79,7 +86,7 @@ class MergeBatchNorm(Canonizer):
 
         Parameters
         ----------
-        linear: list of :py:obj:`torch.nn.Module`
+        linears: list of :py:obj:`torch.nn.Module`
             List of linear layer with mandatory attributes `weight` and `bias`.
         batch_norm: :py:obj:`torch.nn.Module`
             Batch Normalization module with mandatory attributes
@@ -265,8 +272,8 @@ class AttributeCanonizer(Canonizer):
         '''Overload the module's attributes.
 
         Parameters
-        ---------
-        module : :py:obj:`torch.nn.Module`
+        ----------
+        module: :py:obj:`torch.nn.Module`
             The module of which the attributes will be overloaded.
         attributes : dict
             The attributes which to overload for the module.

--- a/src/zennit/cmap.py
+++ b/src/zennit/cmap.py
@@ -76,8 +76,20 @@ class ColorMap:
         return self._source
 
     @source.setter
-    def source(self, value: str):
-        '''Set source code property and re-compile the color map.'''
+    def source(self, value):
+        '''Set source code property and re-compile the color map.
+
+        Parameters
+        ----------
+        value : str
+            The code for the color map.
+
+        Raises
+        ------
+        RuntimeError
+            If the compilation failed, usually due to errors in the code.
+
+        '''
         try:
             tokens = self._lex(value)
             nodes = self._parse(tokens)
@@ -89,12 +101,40 @@ class ColorMap:
 
     @staticmethod
     def _lex(string):
-        '''Lexical scanning of cmsl using regular expressions.'''
+        '''Lexical scanning of cmsl using regular expressions.
+
+        Parameters
+        ----------
+        string : str
+            String to scan.
+
+        Returns
+        -------
+        list of `CMapToken`
+            The resulting tokens.
+
+        '''
         return [CMapToken(match.lastgroup, match.group(), match.start()) for match in ColorMap._rexp.finditer(string)]
 
     @staticmethod
     def _parse(tokens):
-        '''Parse cmsl tokens into a list of color nodes.'''
+        '''Parse cmsl tokens into a list of color nodes.
+
+        Parameters
+        ----------
+        tokens : list of `CMapToken
+            A list of scanned cmsl tokens.
+
+        Returns
+        -------
+        list of `ColorNode`
+            The identified color nodes.
+
+        Raises
+        ------
+        RuntimeError
+            If there was an unexpected token.
+        '''
         nodes = []
         log = []
         for token in tokens:
@@ -129,7 +169,26 @@ class ColorMap:
 
     @staticmethod
     def _make_palette(nodes):
-        '''Generate color map indices and colors from a list of color nodes.'''
+        '''Generate color map indices and colors from a list of color nodes.
+
+        Parameters
+        ----------
+        nodes : list of `ColorNode`
+            The color nodes which identify the color map.
+
+        Returns
+        -------
+        indices : :py:obj:`numpy.ndarray`
+            An array of shape N x 3, where 3 is the number of color nodes, containing the RGB colors.
+        colors : :py:obj:`numpy.ndarray`
+            An array of shape N of type ``numpy.uint8``, which are the indices of the color nodes.
+
+        Raises
+        ------
+        RuntimeError
+            If there are less than 2 colors in the color map.
+
+        '''
         if len(nodes) < 2:
             raise RuntimeError("ColorMap needs at least 2 colors!")
         result = []

--- a/src/zennit/composites.py
+++ b/src/zennit/composites.py
@@ -220,9 +220,33 @@ COMPOSITES = {}
 
 
 def register_composite(name):
-    '''Register a composite in the global COMPOSITES dict under `name`.'''
+    '''Register a composite in the global COMPOSITES dict under `name`.
+
+    Parameters
+    ----------
+    name: str
+        Name under which to register the composite.
+
+    Returns
+    -------
+    wrapped: function
+        The function which will register the composite under the specified name.
+
+    '''
     def wrapped(composite):
-        '''Wrapped function to be called on the composite to register it to the global COMPOSITES dict.'''
+        '''Wrapped function to be called on the composite to register it to the global COMPOSITES dict.
+
+        Parameters
+        ----------
+        composite: :py:obj:`Composite`
+            The composite to register.
+
+        Returns
+        -------
+        composite: :py:obj:`Composite`
+            The original composite.
+
+        '''
         COMPOSITES[name] = composite
         return composite
     return wrapped
@@ -528,6 +552,10 @@ class ExcitationBackprop(LayerMapComposite):
 
     Parameters
     ----------
+    stabilizer: callable or float, optional
+        Stabilization parameter for rules other than ``Epsilon``. If ``stabilizer`` is a float, it will be added to the
+        denominator with the same sign as each respective entry. If it is callable, a function ``(input: torch.Tensor)
+        -> torch.Tensor`` is expected, of which the output corresponds to the stabilized denominator.
     layer_map: list[tuple[tuple[torch.nn.Module, ...], Hook]]
         A mapping as a list of tuples, with a tuple of applicable module types and a Hook. This will be prepended to
         the ``layer_map`` defined by the composite.

--- a/src/zennit/image.py
+++ b/src/zennit/image.py
@@ -130,6 +130,11 @@ def imgify(obj, vmin=None, vmax=None, cmap='bwr', level=1.0, symmetric=False, gr
     -------
     image: obj:`PIL.Image`
         The array visualized as a Pillow Image.
+
+    Raises
+    ------
+    TypeError
+        If the shape of the array cannot be converted to an image.
     '''
     array = np.array(obj)
 
@@ -221,6 +226,11 @@ def gridify(obj, shape=None, fill_value=None):
     obj:`numpy.ndarray`
         An array with the 0-th dimension absorbed into the height and width dimensions (then 0 and 1).
         The color dimension will be the last dimension, even if it was the first dimension before.
+
+    Raises
+    ------
+    TypeError
+        If the shape of the array cannot be converted to an image.
     '''
     array = np.array(obj)
     if array.ndim not in (3, 4):

--- a/src/zennit/layer.py
+++ b/src/zennit/layer.py
@@ -32,5 +32,17 @@ class Sum(torch.nn.Module):
         self.dim = dim
 
     def forward(self, input):
-        '''Computes the sum along a dimension.'''
+        '''Computes the sum along a dimension.
+
+        Parameters
+        ----------
+        input: :py:obj:`torch.Tensor`
+            The input on which to sum.
+
+        Returns
+        -------
+        :py:obj:`torch.Tensor`
+            The resulting tensor summed along dimension `dim`.
+
+        '''
         return torch.sum(input, dim=self.dim)

--- a/src/zennit/torchvision.py
+++ b/src/zennit/torchvision.py
@@ -59,7 +59,20 @@ class ResNetBottleneckCanonizer(AttributeCanonizer):
 
     @staticmethod
     def forward(self, x):
-        '''Modified Bottleneck forward for ResNet.'''
+        '''Modified Bottleneck forward for ResNet.
+
+        Parameters
+        ----------
+        self: :py:obj:`torch.nn.Module`:
+            The module this abstract method will be bound to.
+        x: :py:obj:`torch.Tensor`:
+            The input tensor.
+
+        Returns
+        -------
+        :py:obj:`torch.Tensor`:
+            The resulting output tensor.
+        '''
         identity = x
 
         out = self.conv1(x)
@@ -116,7 +129,20 @@ class ResNetBasicBlockCanonizer(AttributeCanonizer):
 
     @staticmethod
     def forward(self, x):
-        '''Modified BasicBlock forward for ResNet.'''
+        '''Modified BasicBlock forward for ResNet.
+
+        Parameters
+        ----------
+        self: :py:obj:`torch.nn.Module`:
+            The module this abstract method will be bound to.
+        x: :py:obj:`torch.Tensor`:
+            The input tensor.
+
+        Returns
+        -------
+        :py:obj:`torch.Tensor`:
+            The resulting output tensor.
+        '''
         identity = x
 
         out = self.conv1(x)

--- a/src/zennit/types.py
+++ b/src/zennit/types.py
@@ -22,11 +22,33 @@ import torch
 class SubclassMeta(type):
     '''Meta class to bundle multiple subclasses.'''
     def __instancecheck__(cls, inst):
-        """Implement isinstance(inst, cls) as subclasscheck."""
+        """Implement isinstance(inst, cls) as subclasscheck.
+
+        Parameters
+        ----------
+        inst: object
+            The instance to check.
+
+        Returns
+        -------
+        bool
+            True, if `inst` is an instance of `cls`.
+        """
         return cls.__subclasscheck__(type(inst))
 
     def __subclasscheck__(cls, sub):
-        """Implement issubclass(sub, cls) with by considering additional __subclass__ members."""
+        """Implement issubclass(sub, cls) with by considering additional __subclass__ members.
+
+        Parameters
+        ----------
+        sub: object
+            The type to check.
+
+        Returns
+        -------
+        bool
+            True, if `sub` is an instance of `cls`.
+        """
         candidates = cls.__dict__.get("__subclass__", tuple())
         return type.__subclasscheck__(cls, sub) or issubclass(sub, candidates)
 


### PR DESCRIPTION
- this mostly includes typos and forgotten docstrings
- contextmanagers required explicit type hinting for pydoclint to understand