### PR TITLE
Core: Composite Generator, Image: vmin_ vmax_ init

### DIFF
--- a/src/zennit/core.py
+++ b/src/zennit/core.py
@@ -832,7 +832,7 @@ class Composite:
         return CompositeContext(module, self)
 
     @contextmanager
-    def inactive(self) -> Generator[Composite]:
+    def inactive(self) -> Generator:
         '''Context manager to temporarily deactivate the gradient modification. This can be used to compute the
         gradient of the modified gradient.
 

--- a/src/zennit/image.py
+++ b/src/zennit/image.py
@@ -173,6 +173,10 @@ def imgify(obj, vmin=None, vmax=None, cmap='bwr', level=1.0, symmetric=False, gr
         else:
             dims = tuple(range(array.ndim))
 
+        # initialize vmin_ and vmax_, so they are never undefined
+        vmin_, vmax_ = None, None
+
+        # only compute bounds for vmin_ and vmax_ if we really need to
         if None in (vmin, vmax):
             vmin_, vmax_ = interval_norm_bounds(array, symmetric=symmetric, dim=dims)
 


### PR DESCRIPTION
- the `Composite.inactive` context manager yields itself, however, at the point of the definition, Composite cannot be used yet as a type
- in `zennit.image`: initialize vmin_ and vmax_ to None so they are never undefined. This is primarily to circumvent pylint complaining, but might also help in future if the function is changed