### PR TITLE
Core: Remove member type from contextmanager

### DIFF
--- a/src/zennit/core.py
+++ b/src/zennit/core.py
@@ -284,7 +284,7 @@ class ParamMod:
         raise TypeError(f'{modifier} is neither an instance of {cls}, nor callable!')
 
     @contextmanager
-    def __call__(self, module) -> Generator[torch.nn.Module]:
+    def __call__(self, module) -> Generator:
         '''Context manager to temporarily modify parameter attributes (all by default) of a module.
 
         Parameters


### PR DESCRIPTION
- `ParamMod.__call__` is a contextmanager for which the arguments change depending on enter and exit. Python 3.13's Generator is fine with this, but previous Python versions cause a crash. Therefore, remove the typing for this instance