### PR TITLE
Repository: Remove the confusing LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,0 @@
-* Zennit is licensed under the GNU LESSER GENERAL PUBLIC LICENSE VERSION 3 OR
-  LATER -- see the 'COPYING' and 'COPYING.LESSER' files in the root directory for
-  details.


### PR DESCRIPTION
- the license is already provided with COPYING and COPYING.LESSER
- LICENSE was originally added as-per recommendation of the FSF
- however, COPYING and COPYING.LESSER are already sufficient to describe the license, and github got confused by the additional LICENSE file