### PR TITLE
MergeBatchNorm: Set bias to batch-norm bias

### DIFF
--- a/src/zennit/canonizers.py
+++ b/src/zennit/canonizers.py
@@ -132,9 +132,7 @@ class MergeBatchNorm(Canonizer):
 
         for module in modules:
             if module.bias is None:
-                module.bias = torch.nn.Parameter(
-                    torch.zeros(1, device=module.weight.device, dtype=module.weight.dtype)
-                )
+                module.bias = torch.nn.Parameter(torch.zeros_like(batch_norm.bias))
 
             index = (slice(None), *((None,) * (module.weight.ndim - 1)))
             if isinstance(module, ConvolutionTranspose):


### PR DESCRIPTION
- the new way of setting module parameters in hooks caused an issue when biases where undefined, as we always forced a shape of `1`
- as a fix, we can simply compy the shape of the batch_norm