### PR TITLE
CI: Deploy: Do not update dependencies

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,14 +42,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           version: 0.6.13
       - name: Install Python
-        run: uv python install 3.13.2
+        run: uv python install
       - name: Install Zennit and its Dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Build the Zennit Project
         run: uv build
       - name: Publish the Zennit Project to PyPI


### PR DESCRIPTION
- use `uv sync --locked` in order to not update dependencies and bump the version when deploying